### PR TITLE
A huge refactor, building on top of generic pages

### DIFF
--- a/Example/Sources/Example/main.swift
+++ b/Example/Sources/Example/main.swift
@@ -14,25 +14,10 @@ struct AppMetadata: Metadata {
   let images: [String]?
 }
 
-// Add some helper methods to the Page type that Saga provides
+// An easy way to only get public articles, since ArticleMetadata.public is optional
 extension Page where M == ArticleMetadata {
   var `public`: Bool {
     return metadata.public ?? true
-  }
-}
-
-extension AnyPage {
-  var isArticle: Bool {
-    return self is Page<ArticleMetadata>
-  }
-  var isPublicArticle: Bool {
-    return (self as? Page<ArticleMetadata>)?.public ?? false
-  }
-  var isApp: Bool {
-    return self is Page<AppMetadata>
-  }
-  var tags: [String] {
-    return (self as? Page<ArticleMetadata>)?.metadata.tags ?? []
   }
 }
 
@@ -59,84 +44,36 @@ func pageProcessor(page: Page<ArticleMetadata>) {
   ).makeOutputPath()
 }
 
-try Saga(input: "content", output: "deploy")
-  // All markdown files within the "articles" subfolder will be parsed to html,
-  // using ArticleMetadata as the Page's metadata type.
-  .read(
+try Saga(input: "content", output: "deploy", templates: "templates")
+  .register(
     folder: "articles",
     metadata: ArticleMetadata.self,
-    readers: [.markdownReader(pageProcessor: pageProcessor)]
-  )
-  // All markdown files within the "apps" subfolder will be parsed to html,
-  // using AppMetadata as the Page's metadata type.
-  .read(
-    folder: "apps",
-    metadata: AppMetadata.self,
-    readers: [.markdownReader()]
-  )
-  // All the remaining markdown files will be parsed to html,
-  // using the default EmptyMetadata as the Page's metadata type.
-  .read(
-    metadata: EmptyMetadata.self,
-    readers: [.markdownReader()]
-  )
-  // Now that we have read all the markdown pages, we're going to write
-  // them all to disk using a variety of writers.
-  .modifyPages()
-  .write(
-    templates: "templates",
+    readers: [.markdownReader(pageProcessor: pageProcessor)],
+    filter: \.public,
     writers: [
-      // Articles
-      .section(prefix: "articles", filter: \.isPublicArticle, writers: [
-        .pageWriter(template: "article.html"),
-        .listWriter(template: "articles.html"),
-        .tagWriter(template: "tag.html", tags: \.tags),
-        .yearWriter(template: "year.html"),
-      ]),
-
-      // The section writer above does exactly the same as the following lines would do:
-      //
-      // .pageWriter(template: "article.html", filter: { $0.isPublicArticle }),
-      // .listWriter(template: "articles.html", output: "articles/index.html", filter: { $0.isPublicArticle }),
-      // .tagWriter(template: "tag.html", output: "articles/[tag]/index.html", tags: { $0.tags }, filter: { $0.isPublicArticle }),
-      // .yearWriter(template: "year.html", output: "articles/[year]/index.html", filter: { $0.isPublicArticle }),
-      //
-      // So it basically prefixes the `output` and pre-filters the pages so you don't have to do it for every writer.
-
-      // Apps don't get their own individual webpage, instead they are only written using the listWriter
-      .listWriter(template: "apps.html", output: "apps/index.html", filter: \.isApp),
-
-      // Other pages
-      // We specifically filter on EmptyMetadata here, otherwise it might process articles or apps that were not written by the writers above.
-      // For example, there is one article that is not public, so it wouldn't have been written by that first pageWriter. That means all of a
-      // sudden this "less specific" pageWriter would now still write that article to disk, which is not what we want.
-      // Same for the apps: we don't want to write those as individual pages, so if we don't exclude those, we'd still get them written
-      // to disk after all.
-      .pageWriter(template: "page.html", filter: { $0 is Page<EmptyMetadata> }),
-
-      // All pages to the sitemap
-      // We need to exclude the apps, since those are not "real" pages, see comments above.
-      .listWriter(template: "sitemap.xml", output: "sitemap.xml", filter: { !$0.isApp }),
+      .pageWriter(template: "article.html"),
+      .listWriter(template: "articles.html"),
+      .tagWriter(template: "tag.html", tags: \.metadata.tags),
+      .yearWriter(template: "year.html"),
     ]
   )
-  // All the remaining files that were not parsed to markdown, so for example images, raw html files and css,
-  // are copied as-is to the output folder.
+  .register(
+    folder: "apps",
+    metadata: AppMetadata.self,
+    readers: [.markdownReader()],
+    writers: [.listWriter(template: "apps.html")]
+  )
+  .register(
+    metadata: EmptyMetadata.self,
+    readers: [.markdownReader()],
+    writers: [.pageWriter(template: "page.html")]
+  )
+  .run()
   .staticFiles()
-  // Create Twitter preview images for all articles. This only works if you have Python installed with the Pillow dependency.
   .createArticleImages()
 
 
 extension Saga {
-  @discardableResult
-  func modifyPages() -> Self {
-    let pages = fileStorage.compactMap(\.page)
-    for page in pages {
-      page.title.append("!")
-    }
-
-    return self
-  }
-
   @discardableResult
   func createArticleImages() -> Self {
     let articles = fileStorage.compactMap { $0.page as? Page<ArticleMetadata> }

--- a/Example/content/test/index.md
+++ b/Example/content/test/index.md
@@ -1,0 +1,2 @@
+# Index of Test
+Yes

--- a/Example/content/test/subpage.md
+++ b/Example/content/test/subpage.md
@@ -1,0 +1,2 @@
+# Subpage of test
+Yeah!

--- a/Example/templates/article.html
+++ b/Example/templates/article.html
@@ -7,7 +7,7 @@
 <h2>{{ page.date | date:"dd-MM" }}-<a href="/articles/{{ page.date | date:"yyyy" }}/">{{ page.date | date:"yyyy" }}</a></h2>
 <ul>
   {% for tag in page.metadata.tags %}
-  <li><a href="/articles/{{ tag }}/">{{ tag }}</a></li>
+  <li><a href="/articles/tag/{{ tag }}/">{{ tag }}</a></li>
   {% endfor %}
 </ul>
 {{ page.body }}

--- a/Example/templates/articles.html
+++ b/Example/templates/articles.html
@@ -10,4 +10,9 @@
       {{ page.metadata.summary }}
     </p>
   {% endfor %}
+
+  <h1>Apps</h1>
+  {% for page in allPages where page.metadataType == "AppMetadata" %}
+    <p>{{ page.title }}</p>
+  {% endfor %}
 {% endblock %}

--- a/Example/templates/home.html
+++ b/Example/templates/home.html
@@ -3,6 +3,15 @@
 {% block title %}{{ page.title }}{% endblock %}
 
 {% block content %}
-<h1>Hello custom home template!</h1>
 {{ page.body }}
+
+<h1>Articles</h1>
+{% for page in allPages where page.metadataType == "ArticleMetadata" %}
+  <p>{{ page.title }}</p>
+{% endfor %}
+
+<h1>Apps</h1>
+{% for page in allPages where page.metadataType == "AppMetadata" %}
+  <p>{{ page.title }}</p>
+{% endfor %}
 {% endblock %}

--- a/Sources/Saga/FileContainer.swift
+++ b/Sources/Saga/FileContainer.swift
@@ -2,7 +2,7 @@ import PathKit
 
 public class FileContainer {
   public let path: Path
-  public var page: AnyPage?
+  public internal(set) var page: AnyPage?
   public var handled: Bool
 
   internal init(path: Path) {

--- a/Sources/Saga/Page.swift
+++ b/Sources/Saga/Page.swift
@@ -14,13 +14,14 @@ public protocol AnyPage: class {
   var date: Date { get set }
   var lastModified: Date { get set }
   var template: Path? { get set }
+
+  // This is only used in the templates, to be able to do this:
+  // {% for page in allPages where page.metadataType == "ArticleMetadata" %}
+  // This should definitely be removed once Stencil has been replaced with a strongly typed HTML DSL library.
+  var metadataType: String { get }
 }
 
-protocol WritablePage: AnyObject {
-  var written: Bool { get set }
-}
-
-public class Page<M: Metadata>: AnyPage, WritablePage {
+public class Page<M: Metadata>: AnyPage {
   public var relativeSource: Path
   public var relativeDestination: Path
   public var title: String
@@ -29,8 +30,8 @@ public class Page<M: Metadata>: AnyPage, WritablePage {
   public var date: Date
   public var lastModified: Date
   public var metadata: M
+  public var metadataType: String // Remove once Stencil has been replaced
   public var template: Path?
-  internal var written = false
 
   internal init(relativeSource: Path, relativeDestination: Path, title: String, rawContent: String, body: String, date: Date, lastModified: Date, metadata: M, template: Path? = nil) {
     self.relativeSource = relativeSource
@@ -41,7 +42,7 @@ public class Page<M: Metadata>: AnyPage, WritablePage {
     self.date = date
     self.lastModified = lastModified
     self.metadata = metadata
+    self.metadataType = String(String(describing: metadata).split(separator: "(").first!)
     self.template = template
-    self.written = false
   }
 }

--- a/Sources/Saga/ProcessingStep.swift
+++ b/Sources/Saga/ProcessingStep.swift
@@ -1,0 +1,84 @@
+import Foundation
+import PathKit
+import Stencil
+
+internal class ProcessStep<M: Metadata> {
+  let folder: Path?
+  let readers: [Reader<M>]
+  let filter: (Page<M>) -> Bool
+  let writers: [Writer<M>]
+  var pages: [Page<M>]
+
+  init(folder: Path?, readers: [Reader<M>], filter: @escaping (Page<M>) -> Bool, writers: [Writer<M>]) {
+    self.folder = folder
+    self.readers = readers
+    self.filter = filter
+    self.writers = writers
+    self.pages = []
+  }
+}
+
+internal class AnyProcessStep {
+  let step: Any
+  let runReaders: () throws -> ()
+  let runWriters: () throws -> ()
+
+  init<M: Metadata>(step: ProcessStep<M>, fileStorage: [FileContainer], inputPath: Path, outputPath: Path, environment: Environment) {
+    self.step = step
+
+    runReaders = {
+      var pages = [Page<M>]()
+
+      let unhandledFileContainers = fileStorage.filter { $0.handled == false }
+
+      for unhandledFileContainer in unhandledFileContainers {
+        let relativePath = try unhandledFileContainer.path.relativePath(from: inputPath)
+
+        // Only work on files that match the folder (if any)
+        if let folder = step.folder, !relativePath.string.starts(with: folder.string) {
+          continue
+        }
+
+        // Pick the first reader that is able to work on this file, based on file extension
+        guard let reader = step.readers.first(where: { $0.supportedExtensions.contains(relativePath.extension ?? "") }) else {
+          continue
+        }
+
+        // Mark it as handled so that another step that works on a less specific folder doesn't also try to read it
+        unhandledFileContainer.handled = true
+
+        do {
+          // Turn the file into a Page
+          let page = try reader.convert(unhandledFileContainer.path, relativePath)
+
+          // Store the generated Page
+          if step.filter(page) {
+            unhandledFileContainer.page = page
+            pages.append(page)
+          }
+        } catch {
+          // Couldn't convert the file into a Page, probably because of missing metadata
+          // We still mark it has handled, otherwise another, less specific, read step might
+          // pick it up with an EmptyMetadata, turning a broken page suddenly into a working page,
+          // which is probably not what you want.
+          print("❕File \(relativePath) failed conversion to Page<\(M.self)>, error: ", error)
+          continue
+        }
+      }
+
+      step.pages = pages
+    }
+
+    runWriters = {
+      let allPages = fileStorage.compactMap(\.page)
+
+      for writer in step.writers {
+        try writer.write(step.pages, allPages, { template, context, destination in
+          let rendered = try environment.renderTemplate(name: template.string, context: context)
+          try destination.parent().mkpath()
+          try destination.write(rendered)
+        }, outputPath, step.folder ?? "")
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Instead of having separate read and write steps, they are now combined into one step. This removes a lot of now unnecessary code like the section writer, since the combined step now actually behaves the same: writers inside a step are given a prefixed output path, using the folder given for the step - the folder now works for reading *and* writing.

- Page.written is no longer needed, since every step's writers only write the Pages that that step also created, and using filters. So if you have a step that works on the "articles" folder and you're only interested in public articles, a later more generic step working without a prefix folder is not going to pick up that same Page. In fact, these filtered-out pages are not even part of allPages anymore, which they were before.

- Removed the modifyPages step, since this doesn't work anymore. The publishingsteps work on their own array of Pages, not a global storage array that you can freely modify. But that's why all the readers have a processor parameter!

- Added examples of a home page that shows articles and apps, and the articles page showing apps as well.