### PR TITLE
Replaced Ink and Stencil with SwiftMarkdown

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 # 0.8.0 - not released yet
 - Replaced Ink and Stencil with SwiftMarkdown, see https://github.com/loopwerk/Saga/pull/3
+- Added a way to supply custom SiteMetadata, which will be given to every template
 
 # 0.7.0 - 2021-02-03
 - Complete API redesign, see https://github.com/loopwerk/Saga/pull/1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,8 @@
-# 0.8.0 - not released yet
+# 0.8.0 - 2021-02-07
 - Replaced Ink and Stencil with SwiftMarkdown, see https://github.com/loopwerk/Saga/pull/3
 - Added a way to supply custom `SiteMetadata`, which will be given to every template
-- Added `striptags` and `wordcount` filters for Stencil
+- Added `striptags`, `wordcount`, `slugify`, `escape` and `truncate` filters for Stencil
+- Made some previously `internal` things `public`
 
 # 0.7.0 - 2021-02-03
 - Complete API redesign, see https://github.com/loopwerk/Saga/pull/1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
+# 0.8.0 - not released yet
+- Switched out Ink and Stencil for SwiftMarkdown
+
 # 0.7.0 - 2021-02-03
-- Complete API redesign, see #1
+- Complete API redesign, see https://github.com/loopwerk/Saga/pull/1
 
 # 0.6.0 - 2021-02-02
 - Pages can set their own custom template

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 # 0.8.0 - not released yet
 - Replaced Ink and Stencil with SwiftMarkdown, see https://github.com/loopwerk/Saga/pull/3
-- Added a way to supply custom SiteMetadata, which will be given to every template
+- Added a way to supply custom `SiteMetadata`, which will be given to every template
+- Added `striptags` and `wordcount` filters for Stencil
 
 # 0.7.0 - 2021-02-03
 - Complete API redesign, see https://github.com/loopwerk/Saga/pull/1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 # 0.8.0 - not released yet
-- Switched out Ink and Stencil for SwiftMarkdown
+- Replaced Ink and Stencil with SwiftMarkdown, see https://github.com/loopwerk/Saga/pull/3
 
 # 0.7.0 - 2021-02-03
 - Complete API redesign, see https://github.com/loopwerk/Saga/pull/1

--- a/Example/Package.resolved
+++ b/Example/Package.resolved
@@ -56,12 +56,12 @@
         }
       },
       {
-        "package": "SwiftMarkdown2",
-        "repositoryURL": "https://github.com/loopwerk/SwiftMarkdown2",
+        "package": "SwiftMarkdown",
+        "repositoryURL": "https://github.com/loopwerk/SwiftMarkdown",
         "state": {
           "branch": null,
-          "revision": "aa6aae2cd513919c156473c18f8e66d64057b8e8",
-          "version": "0.2.0"
+          "revision": "d4e31602745e922357a4916cfd296b9b2487bd26",
+          "version": "0.1.0"
         }
       }
     ]

--- a/Example/Package.resolved
+++ b/Example/Package.resolved
@@ -11,12 +11,12 @@
         }
       },
       {
-        "package": "Ink",
-        "repositoryURL": "https://github.com/johnsundell/ink.git",
+        "package": "LoggerKit",
+        "repositoryURL": "https://github.com/pvieito/LoggerKit.git",
         "state": {
-          "branch": null,
-          "revision": "bd223a2482449507bd3286cb262c962d32d81e4b",
-          "version": "0.5.0"
+          "branch": "master",
+          "revision": "9a10b40b3bdb6634571122f4a32d61fa34391e74",
+          "version": null
         }
       },
       {
@@ -26,6 +26,24 @@
           "branch": null,
           "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
           "version": "1.0.0"
+        }
+      },
+      {
+        "package": "PythonKit",
+        "repositoryURL": "https://github.com/pvieito/PythonKit.git",
+        "state": {
+          "branch": null,
+          "revision": "260ae70cddeadf42a7a0edce0dfc7f00343b5d1a",
+          "version": null
+        }
+      },
+      {
+        "package": "Rainbow",
+        "repositoryURL": "https://github.com/onevcat/Rainbow",
+        "state": {
+          "branch": null,
+          "revision": "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
+          "version": "3.2.0"
         }
       },
       {
@@ -47,21 +65,30 @@
         }
       },
       {
-        "package": "Splash",
-        "repositoryURL": "https://github.com/JohnSundell/Splash",
-        "state": {
-          "branch": null,
-          "revision": "81de0389558ad40579027735841593b21a511fa8",
-          "version": "0.15.0"
-        }
-      },
-      {
         "package": "Stencil",
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
           "revision": "94197b3adbbf926348ad8765476a158aa4e54f8a",
           "version": "0.14.0"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": "main",
+          "revision": "75c4dcd2e7cd0878aa1d29e6b493a8abcd65d753",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftMarkdown2",
+        "repositoryURL": "https://github.com/loopwerk/SwiftMarkdown2",
+        "state": {
+          "branch": "main",
+          "revision": "e1f2c61b16a4f15f866b7c61afdb4c877591ac28",
+          "version": null
         }
       }
     ]

--- a/Example/Package.resolved
+++ b/Example/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/loopwerk/SwiftMarkdown",
         "state": {
           "branch": null,
-          "revision": "d4e31602745e922357a4916cfd296b9b2487bd26",
-          "version": "0.1.0"
+          "revision": "360a3c9965b184ca488bcc983a1daaddac93f335",
+          "version": "0.2.0"
         }
       }
     ]

--- a/Example/Package.resolved
+++ b/Example/Package.resolved
@@ -11,15 +11,6 @@
         }
       },
       {
-        "package": "LoggerKit",
-        "repositoryURL": "https://github.com/pvieito/LoggerKit.git",
-        "state": {
-          "branch": "master",
-          "revision": "9a10b40b3bdb6634571122f4a32d61fa34391e74",
-          "version": null
-        }
-      },
-      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
@@ -33,17 +24,8 @@
         "repositoryURL": "https://github.com/pvieito/PythonKit.git",
         "state": {
           "branch": null,
-          "revision": "260ae70cddeadf42a7a0edce0dfc7f00343b5d1a",
-          "version": null
-        }
-      },
-      {
-        "package": "Rainbow",
-        "repositoryURL": "https://github.com/onevcat/Rainbow",
-        "state": {
-          "branch": null,
-          "revision": "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
-          "version": "3.2.0"
+          "revision": "074622c6893188bbb7926eee2f7eece8a5124c47",
+          "version": "0.1.0"
         }
       },
       {
@@ -74,21 +56,12 @@
         }
       },
       {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
-        "state": {
-          "branch": "main",
-          "revision": "75c4dcd2e7cd0878aa1d29e6b493a8abcd65d753",
-          "version": null
-        }
-      },
-      {
         "package": "SwiftMarkdown2",
         "repositoryURL": "https://github.com/loopwerk/SwiftMarkdown2",
         "state": {
-          "branch": "main",
-          "revision": "e1f2c61b16a4f15f866b7c61afdb4c877591ac28",
-          "version": null
+          "branch": null,
+          "revision": "aa6aae2cd513919c156473c18f8e66d64057b8e8",
+          "version": "0.2.0"
         }
       }
     ]

--- a/Example/Sources/Example/main.swift
+++ b/Example/Sources/Example/main.swift
@@ -52,7 +52,7 @@ func pageProcessor(page: Page<ArticleMetadata>) {
   let first11 = String(page.relativeSource.lastComponentWithoutExtension.prefix(11))
   page.relativeDestination = Path(
     page.relativeSource.string.replacingOccurrences(of: first11, with: "")
-  ).makeOutputPath()
+  ).makeOutputPath(keepExactPath: false)
 }
 
 try Saga(input: "content", output: "deploy", templates: "templates", siteMetadata: siteMetadata)

--- a/Example/Sources/Example/main.swift
+++ b/Example/Sources/Example/main.swift
@@ -13,6 +13,18 @@ struct AppMetadata: Metadata {
   let images: [String]?
 }
 
+// SiteMetadata is given to every template.
+// You can put whatever you want in here, as long as it's Decodable.
+struct SiteMetadata: Metadata {
+  let url: URL
+  let name: String
+}
+
+let siteMetadata = SiteMetadata(
+  url: URL(string: "http://www.example.com")!,
+  name: "Example website"
+)
+
 // An easy way to only get public articles, since ArticleMetadata.public is optional
 extension Page where M == ArticleMetadata {
   var `public`: Bool {
@@ -43,7 +55,7 @@ func pageProcessor(page: Page<ArticleMetadata>) {
   ).makeOutputPath()
 }
 
-try Saga(input: "content", output: "deploy", templates: "templates")
+try Saga(input: "content", output: "deploy", templates: "templates", siteMetadata: siteMetadata)
   // All markdown files within the "articles" subfolder will be parsed to html,
   // using ArticleMetadata as the Page's metadata type.
   // Furthermore we are only interested in public articles.

--- a/Example/content/index.md
+++ b/Example/content/index.md
@@ -7,6 +7,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer rutrum augue ur
 Phasellus ornare massa lacus, ut accumsan nulla luctus quis. Phasellus vitae condimentum ligula, id maximus arcu. Vivamus sagittis varius scelerisque. Morbi tincidunt, elit at facilisis iaculis, dolor justo bibendum neque, a gravida felis neque dignissim magna. Duis et odio imperdiet, laoreet arcu vitae, consectetur nibh. Vivamus sollicitudin justo odio, molestie accumsan quam efficitur auctor. Praesent quis nibh lectus. Praesent porta augue arcu, quis eleifend ipsum sollicitudin eu. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut efficitur augue quam, quis dignissim odio hendrerit sed. Aliquam consequat leo non erat volutpat elementum. Aenean libero tortor, aliquam non ornare quis, vestibulum tristique justo. Quisque imperdiet euismod urna sit amet blandit. Donec a maximus enim.
 
 This is a test
+
 - One
 - Two
 

--- a/Example/content/index.md
+++ b/Example/content/index.md
@@ -6,7 +6,7 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer rutrum augue ur
 
 Phasellus ornare massa lacus, ut accumsan nulla luctus quis. Phasellus vitae condimentum ligula, id maximus arcu. Vivamus sagittis varius scelerisque. Morbi tincidunt, elit at facilisis iaculis, dolor justo bibendum neque, a gravida felis neque dignissim magna. Duis et odio imperdiet, laoreet arcu vitae, consectetur nibh. Vivamus sollicitudin justo odio, molestie accumsan quam efficitur auctor. Praesent quis nibh lectus. Praesent porta augue arcu, quis eleifend ipsum sollicitudin eu. Interdum et malesuada fames ac ante ipsum primis in faucibus. Ut efficitur augue quam, quis dignissim odio hendrerit sed. Aliquam consequat leo non erat volutpat elementum. Aenean libero tortor, aliquam non ornare quis, vestibulum tristique justo. Quisque imperdiet euismod urna sit amet blandit. Donec a maximus enim.
 
-This is a test
+This is a ~~test~~
 
 - One
 - Two

--- a/Example/content/static/style.css
+++ b/Example/content/static/style.css
@@ -2,57 +2,87 @@ body {
   font-family: Helvetica;
 }
 
+* {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  -ms-box-sizing: border-box;
+  box-sizing: border-box;
+}
+
+/* Pygments syntax highlighter */
+.highlight .hll { background-color: #272822; }
+.highlight .c { color: #75715e } /* Comment */
+.highlight .k { color: #66d9ef } /* Keyword */
+.highlight .l { color: #ae81ff } /* Literal */
+.highlight .n { color: #f8f8f2 } /* Name */
+.highlight .o { color: #f92672 } /* Operator */
+.highlight .p { color: #f8f8f2 } /* Punctuation */
+.highlight .cm { color: #75715e } /* Comment.Multiline */
+.highlight .cp { color: #75715e } /* Comment.Preproc */
+.highlight .c1 { color: #75715e } /* Comment.Single */
+.highlight .cs { color: #75715e } /* Comment.Special */
+.highlight .ge { font-style: italic } /* Generic.Emph */
+.highlight .gs { font-weight: bold } /* Generic.Strong */
+.highlight .kc { color: #66d9ef } /* Keyword.Constant */
+.highlight .kd { color: #66d9ef } /* Keyword.Declaration */
+.highlight .kn { color: #f92672 } /* Keyword.Namespace */
+.highlight .kp { color: #66d9ef } /* Keyword.Pseudo */
+.highlight .kr { color: #66d9ef } /* Keyword.Reserved */
+.highlight .kt { color: #66d9ef } /* Keyword.Type */
+.highlight .ld { color: #e6db74 } /* Literal.Date */
+.highlight .m { color: #ae81ff } /* Literal.Number */
+.highlight .s { color: #e6db74 } /* Literal.String */
+.highlight .na { color: #a6e22e } /* Name.Attribute */
+.highlight .nb { color: #f8f8f2 } /* Name.Builtin */
+.highlight .nc { color: #a6e22e } /* Name.Class */
+.highlight .no { color: #66d9ef } /* Name.Constant */
+.highlight .nd { color: #a6e22e } /* Name.Decorator */
+.highlight .ni { color: #f8f8f2 } /* Name.Entity */
+.highlight .ne { color: #a6e22e } /* Name.Exception */
+.highlight .nf { color: #a6e22e } /* Name.Function */
+.highlight .nl { color: #f8f8f2 } /* Name.Label */
+.highlight .nn { color: #f8f8f2 } /* Name.Namespace */
+.highlight .nx { color: #a6e22e } /* Name.Other */
+.highlight .py { color: #f8f8f2 } /* Name.Property */
+.highlight .nt { color: #f92672 } /* Name.Tag */
+.highlight .nv { color: #f8f8f2 } /* Name.Variable */
+.highlight .ow { color: #f92672 } /* Operator.Word */
+.highlight .w { color: #f8f8f2 } /* Text.Whitespace */
+.highlight .mf { color: #ae81ff } /* Literal.Number.Float */
+.highlight .mh { color: #ae81ff } /* Literal.Number.Hex */
+.highlight .mi { color: #ae81ff } /* Literal.Number.Integer */
+.highlight .mo { color: #ae81ff } /* Literal.Number.Oct */
+.highlight .sb { color: #e6db74 } /* Literal.String.Backtick */
+.highlight .sc { color: #e6db74 } /* Literal.String.Char */
+.highlight .sd { color: #e6db74 } /* Literal.String.Doc */
+.highlight .s2 { color: #e6db74 } /* Literal.String.Double */
+.highlight .se { color: #ae81ff } /* Literal.String.Escape */
+.highlight .sh { color: #e6db74 } /* Literal.String.Heredoc */
+.highlight .si { color: #e6db74 } /* Literal.String.Interpol */
+.highlight .sx { color: #e6db74 } /* Literal.String.Other */
+.highlight .sr { color: #e6db74 } /* Literal.String.Regex */
+.highlight .s1 { color: #e6db74 } /* Literal.String.Single */
+.highlight .ss { color: #e6db74 } /* Literal.String.Symbol */
+.highlight .bp { color: #f8f8f2 } /* Name.Builtin.Pseudo */
+.highlight .vc { color: #f8f8f2 } /* Name.Variable.Class */
+.highlight .vg { color: #f8f8f2 } /* Name.Variable.Global */
+.highlight .vi { color: #f8f8f2 } /* Name.Variable.Instance */
+.highlight .il { color: #ae81ff } /* Literal.Number.Integer.Long */
+.highlight .gu { color: #75715e; } /* Generic.Subheading & Diff Unified/Comment? */
+.highlight .gd { color: #f92672; } /* Generic.Deleted & Diff Deleted */
+.highlight .gi { color: #a6e22e; } /* Generic.Inserted & Diff Inserted */
+
 pre {
-    margin-bottom: 1.5em;
-    background-color: #1a1a1a;
-    padding: 16px 0;
-    border-radius: 16px;
+  font-size: 0.875em;
+  margin-bottom: 1.715em;
+  width: 100%;
+  padding: 1em;
+  overflow: auto;
+  overflow-y: hidden;
 }
 
-pre code {
-    font-family: monospace;
-    display: block;
-    padding: 0 20px;
-    color: #a9bcbc;
-    line-height: 1.4em;
-    font-size: 0.95em;
-    overflow-x: auto;
-    white-space: pre;
-    -webkit-overflow-scrolling: touch;
-}
-
-pre code .keyword {
-    color: #e73289;
-}
-
-pre code .type {
-    color: #8281ca;
-}
-
-pre code .call {
-    color: #348fe5;
-}
-
-pre code .property {
-    color: #21ab9d;
-}
-
-pre code .number {
-    color: #db6f57;
-}
-
-pre code .string {
-    color: #fa641e;
-}
-
-pre code .comment {
-    color: #6b8a94;
-}
-
-pre code .dotAccess {
-    color: #92b300;
-}
-
-pre code .preprocessing {
-    color: #b68a00;
+pre, code {
+  font-family: monospace, sans-serif;
+  background: #393e46;
+  color: #eeeeee;
 }

--- a/Example/templates/article.html
+++ b/Example/templates/article.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <h1>{{ page.title }}</h1>
-<h2>{{ page.date | date:"dd-MM" }}-<a href="/articles/{{ page.date | date:"yyyy" }}/">{{ page.date | date:"yyyy" }}</a></h2>
+<h2>{{ page.date | date:"dd-MM" }}-<a href="/articles/{{ page.date | date:"yyyy" }}/">{{ page.date | date:"yyyy" }}</a>, {{ page.body|striptags|wordcount }} words</h2>
 <ul>
   {% for tag in page.metadata.tags %}
   <li><a href="/articles/tag/{{ tag }}/">{{ tag }}</a></li>

--- a/Example/templates/base.html
+++ b/Example/templates/base.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <title>{% block title %}{% endblock %}</title>
+    <title>{{ site.name }}: {% block title %}{% endblock %}</title>
     <link rel="stylesheet" href="/static/style.css" />
   </head>
   <body>

--- a/Example/templates/home.html
+++ b/Example/templates/home.html
@@ -3,6 +3,7 @@
 {% block title %}{{ page.title }}{% endblock %}
 
 {% block content %}
+<h1>{{ page.title }}</h1>
 {{ page.body }}
 
 <h1>Articles</h1>

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,15 +11,6 @@
         }
       },
       {
-        "package": "LoggerKit",
-        "repositoryURL": "https://github.com/pvieito/LoggerKit.git",
-        "state": {
-          "branch": "master",
-          "revision": "9a10b40b3bdb6634571122f4a32d61fa34391e74",
-          "version": null
-        }
-      },
-      {
         "package": "PathKit",
         "repositoryURL": "https://github.com/kylef/PathKit.git",
         "state": {
@@ -33,17 +24,8 @@
         "repositoryURL": "https://github.com/pvieito/PythonKit.git",
         "state": {
           "branch": null,
-          "revision": "260ae70cddeadf42a7a0edce0dfc7f00343b5d1a",
-          "version": null
-        }
-      },
-      {
-        "package": "Rainbow",
-        "repositoryURL": "https://github.com/onevcat/Rainbow",
-        "state": {
-          "branch": null,
-          "revision": "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
-          "version": "3.2.0"
+          "revision": "074622c6893188bbb7926eee2f7eece8a5124c47",
+          "version": "0.1.0"
         }
       },
       {
@@ -74,21 +56,12 @@
         }
       },
       {
-        "package": "swift-argument-parser",
-        "repositoryURL": "https://github.com/apple/swift-argument-parser",
-        "state": {
-          "branch": "main",
-          "revision": "75c4dcd2e7cd0878aa1d29e6b493a8abcd65d753",
-          "version": null
-        }
-      },
-      {
         "package": "SwiftMarkdown2",
         "repositoryURL": "https://github.com/loopwerk/SwiftMarkdown2",
         "state": {
-          "branch": "main",
-          "revision": "50c182b361a5a7dd3c862c2bf97ed3879f141aa2",
-          "version": null
+          "branch": null,
+          "revision": "aa6aae2cd513919c156473c18f8e66d64057b8e8",
+          "version": "0.2.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -56,12 +56,12 @@
         }
       },
       {
-        "package": "SwiftMarkdown2",
-        "repositoryURL": "https://github.com/loopwerk/SwiftMarkdown2",
+        "package": "SwiftMarkdown",
+        "repositoryURL": "https://github.com/loopwerk/SwiftMarkdown",
         "state": {
           "branch": null,
-          "revision": "aa6aae2cd513919c156473c18f8e66d64057b8e8",
-          "version": "0.2.0"
+          "revision": "d4e31602745e922357a4916cfd296b9b2487bd26",
+          "version": "0.1.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/loopwerk/SwiftMarkdown",
         "state": {
           "branch": null,
-          "revision": "d4e31602745e922357a4916cfd296b9b2487bd26",
-          "version": "0.1.0"
+          "revision": "360a3c9965b184ca488bcc983a1daaddac93f335",
+          "version": "0.2.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -11,12 +11,12 @@
         }
       },
       {
-        "package": "Ink",
-        "repositoryURL": "https://github.com/johnsundell/ink.git",
+        "package": "LoggerKit",
+        "repositoryURL": "https://github.com/pvieito/LoggerKit.git",
         "state": {
-          "branch": null,
-          "revision": "bd223a2482449507bd3286cb262c962d32d81e4b",
-          "version": "0.5.0"
+          "branch": "master",
+          "revision": "9a10b40b3bdb6634571122f4a32d61fa34391e74",
+          "version": null
         }
       },
       {
@@ -26,6 +26,24 @@
           "branch": null,
           "revision": "73f8e9dca9b7a3078cb79128217dc8f2e585a511",
           "version": "1.0.0"
+        }
+      },
+      {
+        "package": "PythonKit",
+        "repositoryURL": "https://github.com/pvieito/PythonKit.git",
+        "state": {
+          "branch": null,
+          "revision": "260ae70cddeadf42a7a0edce0dfc7f00343b5d1a",
+          "version": null
+        }
+      },
+      {
+        "package": "Rainbow",
+        "repositoryURL": "https://github.com/onevcat/Rainbow",
+        "state": {
+          "branch": null,
+          "revision": "626c3d4b6b55354b4af3aa309f998fae9b31a3d9",
+          "version": "3.2.0"
         }
       },
       {
@@ -47,21 +65,30 @@
         }
       },
       {
-        "package": "Splash",
-        "repositoryURL": "https://github.com/JohnSundell/Splash",
-        "state": {
-          "branch": null,
-          "revision": "81de0389558ad40579027735841593b21a511fa8",
-          "version": "0.15.0"
-        }
-      },
-      {
         "package": "Stencil",
         "repositoryURL": "https://github.com/stencilproject/Stencil.git",
         "state": {
           "branch": null,
           "revision": "94197b3adbbf926348ad8765476a158aa4e54f8a",
           "version": "0.14.0"
+        }
+      },
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser",
+        "state": {
+          "branch": "main",
+          "revision": "75c4dcd2e7cd0878aa1d29e6b493a8abcd65d753",
+          "version": null
+        }
+      },
+      {
+        "package": "SwiftMarkdown2",
+        "repositoryURL": "https://github.com/loopwerk/SwiftMarkdown2",
+        "state": {
+          "branch": "main",
+          "revision": "50c182b361a5a7dd3c862c2bf97ed3879f141aa2",
+          "version": null
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.2
 
 import PackageDescription
 

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(name: "SwiftMarkdown2", url: "https://github.com/loopwerk/SwiftMarkdown2", .branch("main")),
+    .package(name: "SwiftMarkdown2", url: "https://github.com/loopwerk/SwiftMarkdown2", from: "0.2.0"),
     .package(name: "Codextended", url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
     .package(name: "Stencil", url: "https://github.com/stencilproject/Stencil.git", from: "0.14.0"),
     .package(name: "Slugify", url: "https://github.com/nodes-vapor/slugify", from: "2.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     ),
   ],
   dependencies: [
+    .package(name: "PathKit", url: "https://github.com/kylef/PathKit.git", from: "1.0.0"),
     .package(name: "SwiftMarkdown", url: "https://github.com/loopwerk/SwiftMarkdown", from: "0.2.0"),
     .package(name: "Codextended", url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
     .package(name: "Stencil", url: "https://github.com/stencilproject/Stencil.git", from: "0.14.0"),
@@ -20,6 +21,7 @@ let package = Package(
     .target(
       name: "Saga",
       dependencies: [
+        "PathKit",
         "SwiftMarkdown",
         "Codextended",
         "Stencil",

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(name: "SwiftMarkdown", url: "https://github.com/loopwerk/SwiftMarkdown", from: "0.1.0"),
+    .package(name: "SwiftMarkdown", url: "https://github.com/loopwerk/SwiftMarkdown", from: "0.2.0"),
     .package(name: "Codextended", url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
     .package(name: "Stencil", url: "https://github.com/stencilproject/Stencil.git", from: "0.14.0"),
     .package(name: "Slugify", url: "https://github.com/nodes-vapor/slugify", from: "2.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(name: "Ink", url: "https://github.com/johnsundell/ink.git", from: "0.2.0"),
-    .package(name: "Splash", url: "https://github.com/JohnSundell/Splash", from: "0.1.0"),
+    .package(name: "SwiftMarkdown2", url: "https://github.com/loopwerk/SwiftMarkdown2", .branch("main")),
     .package(name: "Codextended", url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
     .package(name: "Stencil", url: "https://github.com/stencilproject/Stencil.git", from: "0.14.0"),
     .package(name: "Slugify", url: "https://github.com/nodes-vapor/slugify", from: "2.0.0"),
@@ -21,8 +20,7 @@ let package = Package(
     .target(
       name: "Saga",
       dependencies: [
-        "Ink",
-        "Splash",
+        "SwiftMarkdown2",
         "Codextended",
         "Stencil",
         "Slugify",

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ),
   ],
   dependencies: [
-    .package(name: "SwiftMarkdown2", url: "https://github.com/loopwerk/SwiftMarkdown2", from: "0.2.0"),
+    .package(name: "SwiftMarkdown", url: "https://github.com/loopwerk/SwiftMarkdown", from: "0.1.0"),
     .package(name: "Codextended", url: "https://github.com/johnsundell/codextended.git", from: "0.1.0"),
     .package(name: "Stencil", url: "https://github.com/stencilproject/Stencil.git", from: "0.14.0"),
     .package(name: "Slugify", url: "https://github.com/nodes-vapor/slugify", from: "2.0.0"),
@@ -20,7 +20,7 @@ let package = Package(
     .target(
       name: "Saga",
       dependencies: [
-        "SwiftMarkdown2",
+        "SwiftMarkdown",
         "Codextended",
         "Stencil",
         "Slugify",

--- a/README.md
+++ b/README.md
@@ -28,7 +28,20 @@ struct AppMetadata: Metadata {
   let images: [String]?
 }
 
-try Saga(input: "content", output: "deploy", templates: "templates")
+// SiteMetadata is given to every template.
+// You can put whatever you want in here, as long as it confirms to the Metadata protocol.
+// If you have no need for custom site metadata, just pass EmptyMetadata() to Saga, below.
+struct SiteMetadata: Metadata {
+  let url: URL
+  let name: String
+}
+
+let siteMetadata = SiteMetadata(
+  url: URL(string: "http://www.example.com")!,
+  name: "Example website"
+)
+
+try Saga(input: "content", output: "deploy", templates: "templates", siteMetadata: siteMetadata)
   // All markdown files within the "articles" subfolder will be parsed to html,
   // using ArticleMetadata as the Page's metadata type.
   // Furthermore we are only interested in public articles.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 A static site generator, written in Swift, allowing you to supply your own metadata type for your pages. Read [this series of articles](https://www.loopwerk.io/articles/tag/saga/) discussing the inspiration behind the API, the current state of the project and future plans.
 
+
+## Requirements
+
+- Swift 5
+- Python
+- [Python-Markdown](https://github.com/Python-Markdown/markdown)
+- [Pygments](https://github.com/pygments/pygments) (optional, for syntax highlighting of your code blocks)
+
+If you want to build your website from within Xcode, you'll probably need to install Python-Markdown and Pygments globally.
+
+
+## Usage
+
 Saga is quite flexible: for example you can have one set of metadata for the articles on your blog, and another set of metadata for the apps in your portfolio. At the same time it's quite easy to configure:
 
 ``` swift
@@ -155,16 +168,19 @@ Now, inside of `Sources/MyWebsite/main.swift` you can `import Saga` and use it. 
 - Research a way to auto-run on changes, maybe even reloading the browser as well.
 - Docs and tests.
 
+
 ## Known limitations
 
 - Stencil, the template language, doesn't support rendering computed properties (https://github.com/stencilproject/Stencil/issues/219). So if you extend `Page` with computed properties, you sadly won't be able to render them in your templates.
 - Stencil's template inheritance doesn't support overriding blocks through multiple levels (https://github.com/stencilproject/Stencil/issues/275)
+
 
 ## Thanks
 
 Inspiration for the API of Saga is very much owed to my favorite (but sadly long unmaintained) static site generator: [liquidluck](https://github.com/avelino/liquidluck). Its system of multiple readers and writers is really good and I wanted something similar.
 
 Thanks also goes to [Publish](https://github.com/JohnSundell/Publish), another static site generator written in Swift, for inspiring me towards custom strongly typed metadata. A huge thanks also for its metadata decoder, which was copied over shamelessly.
+
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -151,9 +151,7 @@ Now, inside of `Sources/MyWebsite/main.swift` you can `import Saga` and use it. 
 
 ## TODO
 
-- Remove the page title from the page body - right now it's not possible to add content between the title and the body of an article, something that I do need for my own website.
 - Add paginating support for list/tag/year writers.
-- Replace the Ink and Splash dependencies (see known limitations, below).
 - Research a way to auto-run on changes, maybe even reloading the browser as well.
 - Docs and tests.
 
@@ -161,8 +159,6 @@ Now, inside of `Sources/MyWebsite/main.swift` you can `import Saga` and use it. 
 
 - Stencil, the template language, doesn't support rendering computed properties (https://github.com/stencilproject/Stencil/issues/219). So if you extend `Page` with computed properties, you sadly won't be able to render them in your templates.
 - Stencil's template inheritance doesn't support overriding blocks through multiple levels (https://github.com/stencilproject/Stencil/issues/275)
-- Ink, the Markdown parser, is buggy and is missing features (https://github.com/JohnSundell/Ink/pull/49, https://github.com/JohnSundell/Ink/pull/63). Pull requests don't seem to get merged anymore?
-- Splash, the syntax highlighter, only has support for Swift grammar. If you write articles with, let's say, JavaScript code blocks, they won't get properly highlighted.
 
 ## Thanks
 
@@ -173,7 +169,7 @@ Thanks also goes to [Publish](https://github.com/JohnSundell/Publish), another s
 ## FAQ
 
 Q: Is this ready for production?  
-A: No. This is in very early stages of development, mostly as an exercise. I have no clue if and when I'll finish it or to what degree. I still use [liquidluck](https://github.com/avelino/liquidluck) for my own static sites, which should tell you enough. The API is also not set in stone and may completely change, as it has a few times already.
+A: Almost, but not quite. This is still in early development, and the API is very much subject to change until Saga reaches 1.0.0. I still use [liquidluck](https://github.com/avelino/liquidluck) for my own static sites, which should tell you enough.
 
 Q: How do I view the generated website?  
 A: Personally I use the `serve` tool, installed via Homebrew or NPM, simply run `serve deploy` from within the Example folder.

--- a/Sources/Saga/MarkdownReader.swift
+++ b/Sources/Saga/MarkdownReader.swift
@@ -10,7 +10,7 @@ let config = [
   ]
 ]
 let parser = try! SwiftMarkdown(
-  extensions: [.nl2br, .fencedCode, .codehilite, .strikethrough, .smarty, .title, .meta, .saneLists],
+  extensions: [.nl2br, .fencedCode, .codehilite, .strikethrough, .title, .meta, .saneLists],
   extensionConfig: config
 )
 

--- a/Sources/Saga/MarkdownReader.swift
+++ b/Sources/Saga/MarkdownReader.swift
@@ -4,17 +4,23 @@ import Codextended
 import PathKit
 import Slugify
 
+let config = [
+  "codehilite": [
+    "css_class": "highlight"
+  ]
+]
+let parser = try! SwiftMarkdown(
+  extensions: [.nl2br, .fencedCode, .codehilite, .strikethrough, .smarty, .title, .meta, .saneLists],
+  extensionConfig: config
+)
+
 public extension Reader {
   static func markdownReader(pageProcessor: ((Page<M>) -> Void)? = nil) -> Self {
     Reader(supportedExtensions: ["md", "markdown"], convert: { path, relativePath in
       let contents: String = try path.read()
 
       // First we parse the markdown file
-      let config = [
-        "codehilite": ["css_class": "highlight"]
-      ]
-
-      let markdown = try SwiftMarkdown.markdown(contents, extensions: [.nl2br, .fencedCode, .codehilite, .strikethrough, .smarty, .title, .meta, .saneLists], extensionConfig: config)
+      let markdown = parser.markdown(contents)
 
       // Then we try to decode the embedded metadata within the markdown (which otherwise is just a [String: String] dict)
       let decoder = makeMetadataDecoder(for: markdown)

--- a/Sources/Saga/MarkdownReader.swift
+++ b/Sources/Saga/MarkdownReader.swift
@@ -23,7 +23,7 @@ public extension Reader {
       let markdown = parser.markdown(contents)
 
       // Then we try to decode the embedded metadata within the markdown (which otherwise is just a [String: String] dict)
-      let decoder = makeMetadataDecoder(for: markdown)
+      let decoder = makeMetadataDecoder(for: markdown.metadata)
       let date = try resolvePublishingDate(from: path, decoder: decoder)
       let metadata = try M.init(from: decoder)
       let template = try decoder.decodeIfPresent("template", as: String.self)
@@ -50,14 +50,14 @@ public extension Reader {
   }
 }
 
-private extension Reader {
-  static func makeMetadataDecoder(for markdown: Markdown) -> MetadataDecoder {
+public extension Reader {
+  static func makeMetadataDecoder(for metadata: [String: String]) -> MetadataDecoder {
     let dateFormatter = DateFormatter()
     dateFormatter.dateFormat = "yyyy-MM-dd"
     dateFormatter.timeZone = .current
 
     return MetadataDecoder(
-      metadata: markdown.metadata,
+      metadata: metadata,
       dateFormatter: dateFormatter
     )
   }

--- a/Sources/Saga/MarkdownReader.swift
+++ b/Sources/Saga/MarkdownReader.swift
@@ -1,5 +1,5 @@
 import Foundation
-import SwiftMarkdown2
+import SwiftMarkdown
 import Codextended
 import PathKit
 import Slugify
@@ -10,7 +10,11 @@ public extension Reader {
       let contents: String = try path.read()
 
       // First we parse the markdown file
-      let markdown = try SwiftMarkdown2.markdown(contents, extras: [.breakOnNewline, .cuddledLists, .fencedCodeBlocks, .metadata, .strike, .smartyPants])
+      let config = [
+        "codehilite": ["css_class": "highlight"]
+      ]
+
+      let markdown = try SwiftMarkdown.markdown(contents, extensions: [.nl2br, .fencedCode, .codehilite, .strikethrough, .smarty, .title, .meta, .saneLists], extensionConfig: config)
 
       // Then we try to decode the embedded metadata within the markdown (which otherwise is just a [String: String] dict)
       let decoder = makeMetadataDecoder(for: markdown)
@@ -22,7 +26,7 @@ public extension Reader {
       let page = Page(
         relativeSource: relativePath,
         relativeDestination: relativePath.makeOutputPath(),
-        title: path.lastComponentWithoutExtension,
+        title: markdown.title ?? path.lastComponentWithoutExtension,
         rawContent: contents,
         body: markdown.html,
         date: date,

--- a/Sources/Saga/MarkdownReader.swift
+++ b/Sources/Saga/MarkdownReader.swift
@@ -2,7 +2,6 @@ import Foundation
 import SwiftMarkdown
 import Codextended
 import PathKit
-import Slugify
 
 let config = [
   "codehilite": [
@@ -47,22 +46,5 @@ public extension Reader {
 
       return page
     })
-  }
-}
-
-public extension Reader {
-  static func makeMetadataDecoder(for metadata: [String: String]) -> MetadataDecoder {
-    let dateFormatter = DateFormatter()
-    dateFormatter.dateFormat = "yyyy-MM-dd"
-    dateFormatter.timeZone = .current
-
-    return MetadataDecoder(
-      metadata: metadata,
-      dateFormatter: dateFormatter
-    )
-  }
-
-  static func resolvePublishingDate(from path: Path, decoder: MetadataDecoder) throws -> Date {
-    return try decoder.decodeIfPresent("date", as: Date.self) ?? path.modificationDate ?? Date()
   }
 }

--- a/Sources/Saga/MarkdownReader.swift
+++ b/Sources/Saga/MarkdownReader.swift
@@ -25,7 +25,6 @@ public extension Reader {
       // Create the Page
       let page = Page(
         relativeSource: relativePath,
-        relativeDestination: relativePath.makeOutputPath(),
         title: markdown.title ?? path.lastComponentWithoutExtension,
         rawContent: contents,
         body: markdown.html,

--- a/Sources/Saga/MetadataDecoder.swift
+++ b/Sources/Saga/MetadataDecoder.swift
@@ -6,15 +6,15 @@
 
 import Foundation
 
-internal final class MetadataDecoder: Decoder {
-  var userInfo: [CodingUserInfoKey : Any] { [:] }
-  let codingPath: [CodingKey]
+public final class MetadataDecoder: Decoder {
+  public var userInfo: [CodingUserInfoKey : Any] { [:] }
+  public let codingPath: [CodingKey]
 
   private let metadata: [String : String]
   private let dateFormatter: DateFormatter
   private lazy var keyedContainers = [ObjectIdentifier : Any]()
 
-  init(metadata: [String : String],
+  public init(metadata: [String : String],
        codingPath: [CodingKey] = [],
        dateFormatter: DateFormatter) {
     self.metadata = metadata
@@ -22,7 +22,7 @@ internal final class MetadataDecoder: Decoder {
     self.dateFormatter = dateFormatter
   }
 
-  func container<T: CodingKey>(
+  public func container<T: CodingKey>(
     keyedBy type: T.Type
   ) throws -> KeyedDecodingContainer<T> {
     let typeID = ObjectIdentifier(type)
@@ -41,7 +41,7 @@ internal final class MetadataDecoder: Decoder {
     return KeyedDecodingContainer(container)
   }
 
-  func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+  public func unkeyedContainer() throws -> UnkeyedDecodingContainer {
     let prefix = codingPath.asPrefix(includingTrailingSeparator: false)
 
     guard let string = metadata[prefix] else {
@@ -54,7 +54,7 @@ internal final class MetadataDecoder: Decoder {
     )
   }
 
-  func singleValueContainer() throws -> SingleValueDecodingContainer {
+  public func singleValueContainer() throws -> SingleValueDecodingContainer {
     let prefix = codingPath.asPrefix(includingTrailingSeparator: false)
 
     guard let string = metadata[prefix] else {

--- a/Sources/Saga/Page.swift
+++ b/Sources/Saga/Page.swift
@@ -6,8 +6,9 @@ public protocol Metadata: Decodable {}
 public struct EmptyMetadata: Metadata {}
 
 public protocol AnyPage: class {
-  var relativeSource: Path { get set }
-  var relativeDestination: Path { get set }
+  var relativeSource: Path { get }
+  var filenameWithoutExtension: String { get }
+  var relativeDestination: Path { get set } /// if empty, it'll be calculated by the pageWriter
   var title: String { get set }
   var rawContent: String { get set }
   var body: String { get set }
@@ -22,7 +23,8 @@ public protocol AnyPage: class {
 }
 
 public class Page<M: Metadata>: AnyPage {
-  public var relativeSource: Path
+  public let relativeSource: Path
+  public let filenameWithoutExtension: String
   public var relativeDestination: Path
   public var title: String
   public var rawContent: String
@@ -33,8 +35,9 @@ public class Page<M: Metadata>: AnyPage {
   public var metadataType: String // Remove once Stencil has been replaced
   public var template: Path?
 
-  internal init(relativeSource: Path, relativeDestination: Path, title: String, rawContent: String, body: String, date: Date, lastModified: Date, metadata: M, template: Path? = nil) {
+  internal init(relativeSource: Path, relativeDestination: Path = "", title: String, rawContent: String, body: String, date: Date, lastModified: Date, metadata: M, template: Path? = nil) {
     self.relativeSource = relativeSource
+    self.filenameWithoutExtension = relativeSource.lastComponentWithoutExtension
     self.relativeDestination = relativeDestination
     self.title = title
     self.rawContent = rawContent

--- a/Sources/Saga/Page.swift
+++ b/Sources/Saga/Page.swift
@@ -35,7 +35,7 @@ public class Page<M: Metadata>: AnyPage {
   public var metadataType: String // Remove once Stencil has been replaced
   public var template: Path?
 
-  internal init(relativeSource: Path, relativeDestination: Path = "", title: String, rawContent: String, body: String, date: Date, lastModified: Date, metadata: M, template: Path? = nil) {
+  public init(relativeSource: Path, relativeDestination: Path = "", title: String, rawContent: String, body: String, date: Date, lastModified: Date, metadata: M, template: Path? = nil) {
     self.relativeSource = relativeSource
     self.filenameWithoutExtension = relativeSource.lastComponentWithoutExtension
     self.relativeDestination = relativeDestination

--- a/Sources/Saga/Path+Extensions.swift
+++ b/Sources/Saga/Path+Extensions.swift
@@ -2,9 +2,13 @@ import PathKit
 import Foundation
 
 public extension Path {
-  func makeOutputPath() -> Path {
+  /// keepExactPath=true means that a file such as content/404.md will be written as deploy/404.html
+  /// keepExactPath=false will instead write it to deploy/404/index.html
+  func makeOutputPath(keepExactPath: Bool) -> Path {
     if self.lastComponentWithoutExtension == "index" {
       return self.parent() + "index.html"
+    } else if keepExactPath {
+      return self.parent() + (self.lastComponentWithoutExtension.slugify() + ".html")
     } else {
       return self.parent() + self.lastComponentWithoutExtension.slugify() + "index.html"
     }

--- a/Sources/Saga/Path+Extensions.swift
+++ b/Sources/Saga/Path+Extensions.swift
@@ -5,9 +5,7 @@ public extension Path {
   /// keepExactPath=true means that a file such as content/404.md will be written as deploy/404.html
   /// keepExactPath=false will instead write it to deploy/404/index.html
   func makeOutputPath(keepExactPath: Bool) -> Path {
-    if self.lastComponentWithoutExtension == "index" {
-      return self.parent() + "index.html"
-    } else if keepExactPath {
+    if keepExactPath {
       return self.parent() + (self.lastComponentWithoutExtension.slugify() + ".html")
     } else {
       return self.parent() + self.lastComponentWithoutExtension.slugify() + "index.html"

--- a/Sources/Saga/ProcessingStep.swift
+++ b/Sources/Saga/ProcessingStep.swift
@@ -63,11 +63,13 @@ internal class AnyProcessStep {
         }
       }
 
-      step.pages = pages
+      step.pages = pages.sorted(by: { left, right in left.date > right.date })
     }
 
     runWriters = {
-      let allPages = fileStorage.compactMap(\.page)
+      let allPages = fileStorage
+        .compactMap(\.page)
+        .sorted(by: { left, right in left.date > right.date })
 
       for writer in step.writers {
         try writer.write(step.pages, allPages, siteMetadata, { template, context, destination in

--- a/Sources/Saga/ProcessingStep.swift
+++ b/Sources/Saga/ProcessingStep.swift
@@ -2,14 +2,14 @@ import Foundation
 import PathKit
 import Stencil
 
-internal class ProcessStep<M: Metadata> {
+internal class ProcessStep<M: Metadata, SiteMetadata: Metadata> {
   let folder: Path?
   let readers: [Reader<M>]
   let filter: (Page<M>) -> Bool
-  let writers: [Writer<M>]
+  let writers: [Writer<M, SiteMetadata>]
   var pages: [Page<M>]
 
-  init(folder: Path?, readers: [Reader<M>], filter: @escaping (Page<M>) -> Bool, writers: [Writer<M>]) {
+  init(folder: Path?, readers: [Reader<M>], filter: @escaping (Page<M>) -> Bool, writers: [Writer<M, SiteMetadata>]) {
     self.folder = folder
     self.readers = readers
     self.filter = filter
@@ -19,13 +19,10 @@ internal class ProcessStep<M: Metadata> {
 }
 
 internal class AnyProcessStep {
-  let step: Any
   let runReaders: () throws -> ()
   let runWriters: () throws -> ()
 
-  init<M: Metadata>(step: ProcessStep<M>, fileStorage: [FileContainer], inputPath: Path, outputPath: Path, environment: Environment) {
-    self.step = step
-
+  init<M: Metadata, SiteMetadata: Metadata>(step: ProcessStep<M, SiteMetadata>, fileStorage: [FileContainer], inputPath: Path, outputPath: Path, environment: Environment, siteMetadata: SiteMetadata) {
     runReaders = {
       var pages = [Page<M>]()
 
@@ -73,7 +70,7 @@ internal class AnyProcessStep {
       let allPages = fileStorage.compactMap(\.page)
 
       for writer in step.writers {
-        try writer.write(step.pages, allPages, { template, context, destination in
+        try writer.write(step.pages, allPages, siteMetadata, { template, context, destination in
           let rendered = try environment.renderTemplate(name: template.string, context: context)
           try destination.parent().mkpath()
           try destination.write(rendered)

--- a/Sources/Saga/Reader+Decoder.swift
+++ b/Sources/Saga/Reader+Decoder.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Codextended
+import PathKit
+
+public extension Reader {
+  static func makeMetadataDecoder(for metadata: [String: String]) -> MetadataDecoder {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+    dateFormatter.timeZone = .current
+
+    return MetadataDecoder(
+      metadata: metadata,
+      dateFormatter: dateFormatter
+    )
+  }
+
+  static func resolvePublishingDate(from path: Path, decoder: MetadataDecoder) throws -> Date {
+    return try decoder.decodeIfPresent("date", as: Date.self) ?? path.modificationDate ?? Date()
+  }
+}

--- a/Sources/Saga/Reader.swift
+++ b/Sources/Saga/Reader.swift
@@ -3,4 +3,9 @@ import PathKit
 public struct Reader<M: Metadata> {
   var supportedExtensions: [String]
   var convert: (Path, Path) throws -> Page<M>
+
+  public init(supportedExtensions: [String], convert: @escaping (Path, Path) throws -> Page<M>) {
+    self.supportedExtensions = supportedExtensions
+    self.convert = convert
+  }
 }

--- a/Sources/Saga/Saga.swift
+++ b/Sources/Saga/Saga.swift
@@ -124,6 +124,32 @@ private extension Saga {
       return text.numberOfWords
     }
 
+    ext.registerFilter("slugify") { (value: Any) in
+      guard let text = value as? String else {
+        return value
+      }
+      return text.slugify()
+    }
+
+    ext.registerFilter("escape") { (value: Any) in
+      guard let text = value as? String else {
+        return value
+      }
+      return text
+        .replacingOccurrences(of: "<", with: "&lt;")
+        .replacingOccurrences(of: ">", with: "&gt;")
+        .replacingOccurrences(of: "\"", with: "&quot;")
+        .replacingOccurrences(of: "&", with: "&amp;")
+    }
+
+    ext.registerFilter("truncate") { (value: Any, arguments: [Any?]) in
+      guard let text = value as? String else {
+        return value
+      }
+      let length = arguments.first as? Int ?? 255
+      return text.prefix(length)
+    }
+
     let templatePath = rootPath + templates
     return Environment(loader: FileSystemLoader(paths: [templatePath]), extensions: [ext])
   }
@@ -143,7 +169,7 @@ private extension String {
   // is not available in CoreFoundation.
   var withoutHtmlTags: String {
     return self
-      .replacingOccurrences(of: "(?m)<pre><span></span><code>[\\s\\S]+</code></pre>", with: "", options: .regularExpression, range: nil)
+      .replacingOccurrences(of: "(?m)<pre><span></span><code>[\\s\\S]+?</code></pre>", with: "", options: .regularExpression, range: nil)
       .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression, range: nil)
   }
 }

--- a/Sources/Saga/Saga.swift
+++ b/Sources/Saga/Saga.swift
@@ -110,7 +110,38 @@ private extension Saga {
       return url
     }
 
+    ext.registerFilter("striptags") { (value: Any) in
+      guard let text = value as? String else {
+        return value
+      }
+      return text.withoutHtmlTags
+    }
+
+    ext.registerFilter("wordcount") { (value: Any) in
+      guard let text = value as? String else {
+        return value
+      }
+      return text.numberOfWords
+    }
+
     let templatePath = rootPath + templates
     return Environment(loader: FileSystemLoader(paths: [templatePath]), extensions: [ext])
+  }
+}
+
+private extension String {
+  var numberOfWords: Int {
+    var count = 0
+    let range = startIndex..<endIndex
+    enumerateSubstrings(in: range, options: [.byWords, .substringNotRequired, .localized], { _, _, _, _ -> () in
+      count += 1
+    })
+    return count
+  }
+
+  // This is a sloppy implementation but sadly `NSAttributedString(data:options:documentAttributes:)`
+  // is not available in CoreFoundation.
+  var withoutHtmlTags: String {
+    return self.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression, range: nil)
   }
 }

--- a/Sources/Saga/Saga.swift
+++ b/Sources/Saga/Saga.swift
@@ -142,6 +142,8 @@ private extension String {
   // This is a sloppy implementation but sadly `NSAttributedString(data:options:documentAttributes:)`
   // is not available in CoreFoundation.
   var withoutHtmlTags: String {
-    return self.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression, range: nil)
+    return self
+      .replacingOccurrences(of: "(?m)<pre><span></span><code>[\\s\\S]+</code></pre>", with: "", options: .regularExpression, range: nil)
+      .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression, range: nil)
   }
 }

--- a/Sources/Saga/Writer.swift
+++ b/Sources/Saga/Writer.swift
@@ -2,7 +2,24 @@ import PathKit
 import Foundation
 
 public struct Writer<M: Metadata, SiteMetadata: Metadata> {
-  var write: ([Page<M>], [AnyPage], SiteMetadata, (Path, [String : Any], Path) throws -> Void, Path, Path) throws -> Void
+  public var write: (
+    _ pages: [Page<M>],
+    _ allPages: [AnyPage],
+    _ siteMetadata: SiteMetadata,
+    _ render: (Path, [String : Any], Path) throws -> Void,
+    _ outputPath: Path,
+    _ outputPrefix: Path) throws -> Void
+
+  /// Parameters
+  /// pages: [Page<M>]
+  /// allPages: [AnyPage]
+  /// siteMetadata: SiteMetadata
+  /// render: (Path, [String : Any], Path) throws -> Void
+  /// outputPath: Path
+  /// outputPrefix: Path
+  public init(write: @escaping ([Page<M>], [AnyPage], SiteMetadata, (Path, [String : Any], Path) throws -> Void, Path, Path) throws -> Void) {
+    self.write = write
+  }
 }
 
 public extension Writer {

--- a/Sources/Saga/Writer.swift
+++ b/Sources/Saga/Writer.swift
@@ -7,7 +7,7 @@ public struct Writer<M: Metadata, SiteMetadata: Metadata> {
 
 public extension Writer {
   // Write a single Page to disk, using Page.destination as the destination path
-  static func pageWriter(template: Path, filter: @escaping ((Page<M>) -> Bool) = { _ in true }) -> Self {
+  static func pageWriter(template: Path, keepExactPath: Bool = false, filter: @escaping ((Page<M>) -> Bool) = { _ in true }) -> Self {
     return Self { pages, allPages, siteMetadata, render, outputRoot, outputPrefix in
       let pages = pages.filter(filter)
 
@@ -20,7 +20,14 @@ public extension Writer {
         ] as [String : Any]
 
         // Call out to the render function
-        try render(page.template ?? template, context, outputRoot + page.relativeDestination)
+        var destination: Path
+        if page.relativeDestination.string.isEmpty {
+          destination = page.relativeSource.makeOutputPath(keepExactPath: keepExactPath)
+        } else {
+          destination = page.relativeDestination
+        }
+
+        try render(page.template ?? template, context, outputRoot + destination)
       }
     }
   }
@@ -107,7 +114,7 @@ public extension Writer {
         ] as [String : Any]
 
         // Call out to the render function
-        let yearOutput = output.string.replacingOccurrences(of: "[tag]", with: tag)
+        let yearOutput = output.string.replacingOccurrences(of: "[tag]", with: tag.slugify())
         try render(template, context, outputRoot + outputPrefix + yearOutput)
       }
     }

--- a/Sources/Saga/Writer.swift
+++ b/Sources/Saga/Writer.swift
@@ -1,14 +1,14 @@
 import PathKit
 import Foundation
 
-public struct Writer<M: Metadata> {
-  var write: ([Page<M>], [AnyPage], (Path, [String : Any], Path) throws -> Void, Path, Path) throws -> Void
+public struct Writer<M: Metadata, SiteMetadata: Metadata> {
+  var write: ([Page<M>], [AnyPage], SiteMetadata, (Path, [String : Any], Path) throws -> Void, Path, Path) throws -> Void
 }
 
 public extension Writer {
   // Write a single Page to disk, using Page.destination as the destination path
   static func pageWriter(template: Path, filter: @escaping ((Page<M>) -> Bool) = { _ in true }) -> Self {
-    return Self { pages, allPages, render, outputRoot, outputPrefix in
+    return Self { pages, allPages, siteMetadata, render, outputRoot, outputPrefix in
       let pages = pages.filter(filter)
 
       for page in pages {
@@ -16,6 +16,7 @@ public extension Writer {
           "page": page,
           "pages": pages,
           "allPages": allPages,
+          "site": siteMetadata,
         ] as [String : Any]
 
         // Call out to the render function
@@ -27,12 +28,13 @@ public extension Writer {
   // Writes an array of Pages into a single output file.
   // As such, it needs an output path, for example "articles/index.html".
   static func listWriter(template: Path, output: Path = "index.html", filter: @escaping ((Page<M>) -> Bool) = { _ in true }) -> Self {
-    return Self { pages, allPages, render, outputRoot, outputPrefix in
+    return Self { pages, allPages, siteMetadata, render, outputRoot, outputPrefix in
       let pages = pages.filter(filter)
 
       let context = [
         "pages": pages,
         "allPages": allPages,
+        "site": siteMetadata,
       ] as [String : Any]
 
       // Call out to the render function
@@ -44,7 +46,7 @@ public extension Writer {
   // The output path is a template where [year] will be replaced with the year of the Page.
   // Example: "articles/[year]/index.html"
   static func yearWriter(template: Path, output: Path = "[year]/index.html", filter: @escaping ((Page<M>) -> Bool) = { _ in true }) -> Self {
-    return Self { pages, allPages, render, outputRoot, outputPrefix in
+    return Self { pages, allPages, siteMetadata, render, outputRoot, outputPrefix in
       let pages = pages.filter(filter)
 
       // Find all the years and their pages
@@ -65,6 +67,7 @@ public extension Writer {
           "year": year,
           "pages": pagesInYear,
           "allPages": allPages,
+          "site": siteMetadata,
         ] as [String : Any]
 
         // Call out to the render function
@@ -78,7 +81,7 @@ public extension Writer {
   // The output path is a template where [tag] will be replaced with the slugified tag.
   // Example: "articles/tag/[tag]/index.html"
   static func tagWriter(template: Path, output: Path = "tag/[tag]/index.html", tags: @escaping (Page<M>) -> [String], filter: @escaping ((Page<M>) -> Bool) = { _ in true }) -> Self {
-    return Self { pages, allPages, render, outputRoot, outputPrefix in
+    return Self { pages, allPages, siteMetadata, render, outputRoot, outputPrefix in
       let pages = pages.filter(filter)
 
       // Find all the tags and their pages
@@ -100,6 +103,7 @@ public extension Writer {
           "tag": tag,
           "pages": pagesInTag,
           "allPages": allPages,
+          "site": siteMetadata,
         ] as [String : Any]
 
         // Call out to the render function

--- a/Sources/Saga/Writer.swift
+++ b/Sources/Saga/Writer.swift
@@ -1,5 +1,6 @@
 import PathKit
 import Foundation
+import Slugify
 
 public struct Writer<M: Metadata, SiteMetadata: Metadata> {
   public var write: (


### PR DESCRIPTION
When I started Saga, I initially chose to use Ink and Splash for the actual Markdown parsing and code block highlighting. Sadly both are young projects with lots of missing features. For example Splash, the code highlighter, only supports Swift code, which is obviously not enough for a general-purpose static site generator. And Ink, the Markdown parser, has quite a lot of formatting bugs that have already stopped me from using it for my own website. At the time of writing there are 21 open pull requests with all sorts of fixes, some over a year old, but they're not getting any attention it seems. It doesn't feel smart to rely on these two dependencies going forward.

I looked very hard for pure Swift replacements, but sadly nothing comes close to the reliability of [Python-Markdown](https://github.com/Python-Markdown/markdown) and [Pygments](https://github.com/pygments/pygments). So, I created my own wrapped [SwiftMarkdown](https://github.com/loopwerk/SwiftMarkdown)! This does make Saga harder to setup, as you now need to install Python dependencies, but I feel this is worth it due to the massive improvement of the actual output that's generated.

As soon as pure Swift replacements come along with the same quality, I'll gladly switch to those.