### PR TITLE
feat: add seoTitle to Item with independent title priority logic

### DIFF
--- a/Sources/Saga/Item.swift
+++ b/Sources/Saga/Item.swift
@@ -19,6 +19,7 @@ public protocol AnyItem: AnyObject, Sendable {
   var filenameWithoutExtension: String { get }
   var relativeDestination: Path { get set }
   var title: String { get set }
+  var seoTitle: String { get set }
   var body: String { get set }
   var date: Date { get set }
   var created: Date { get }
@@ -43,8 +44,23 @@ public class Item<M: Metadata>: AnyItem, Codable, @unchecked Sendable {
   /// The destination, where the ``Writer`` will write it to disk.
   public var relativeDestination: Path
 
-  /// The title of the item.
+  /// The display title of the item, intended for use as the visible `<h1>` on the page.
+  ///
+  /// Priority: `# ` heading in the markdown body → `title:` front matter → filename.
+  ///
+  /// If the markdown body begins with a `# ` heading, that heading is extracted by the
+  /// reader and given the highest priority here. This lets authors write a rich, human-
+  /// friendly headline in Markdown while using `title:` purely for SEO purposes.
   public var title: String
+
+  /// The SEO title of the item, intended for use in the HTML `<title>` tag and meta tags.
+  ///
+  /// Priority: `title:` front matter → `# ` heading in the markdown body → filename.
+  ///
+  /// This is the mirror of ``title``: it gives the explicit front-matter `title:` key the
+  /// highest priority so authors can craft a keyword-optimised page title that differs from
+  /// the human-readable `<h1>`. Both properties always resolve to a non-empty string.
+  public var seoTitle: String
 
   /// The body of the file, without the metadata header, and without the first title.
   public var body: String
@@ -91,11 +107,12 @@ public class Item<M: Metadata>: AnyItem, Codable, @unchecked Sendable {
     translations[locale] as? Item<M>
   }
 
-  public init(absoluteSource: Path, relativeSource: Path, relativeDestination: Path, title: String, body: String, date: Date, created: Date, lastModified: Date, metadata: M) {
+  public init(absoluteSource: Path, relativeSource: Path, relativeDestination: Path, title: String, seoTitle: String, body: String, date: Date, created: Date, lastModified: Date, metadata: M) {
     self.absoluteSource = absoluteSource
     self.relativeSource = relativeSource
     self.relativeDestination = relativeDestination
     self.title = title
+    self.seoTitle = seoTitle
     self.body = body
     self.date = date
     self.created = created
@@ -106,17 +123,19 @@ public class Item<M: Metadata>: AnyItem, Codable, @unchecked Sendable {
   /// Create an Item programmatically (without reading from a file).
   ///
   /// - Parameters:
-  ///   - title: The title of the item.
+  ///   - title: The display title of the item (used for `<h1>`).
+  ///   - seoTitle: The SEO title for the HTML `<title>` tag. Defaults to `title` when not provided.
   ///   - body: The body content. Defaults to an empty string.
   ///   - date: The date of the item. Defaults to the current date.
   ///   - relativeDestination: The output path relative to the site's output folder. Defaults to `title-slug/index.html`.
   ///   - metadata: The parsed metadata.
-  public convenience init(title: String, body: String = "", date: Date = Date(), relativeDestination: Path? = nil, metadata: M) {
+  public convenience init(title: String, seoTitle: String? = nil, body: String = "", date: Date = Date(), relativeDestination: Path? = nil, metadata: M) {
     self.init(
       absoluteSource: Path(""),
       relativeSource: Path(""),
       relativeDestination: relativeDestination ?? Path("\(title.slugified)/index.html"),
       title: title,
+      seoTitle: seoTitle ?? title,
       body: body,
       date: date,
       created: date,
@@ -134,6 +153,6 @@ public class Item<M: Metadata>: AnyItem, Codable, @unchecked Sendable {
   }
 
   enum CodingKeys: String, CodingKey {
-    case absoluteSource, relativeSource, relativeDestination, title, body, date, created, lastModified, metadata
+    case absoluteSource, relativeSource, relativeDestination, title, seoTitle, body, date, created, lastModified, metadata
   }
 }

--- a/Sources/Saga/Saga+Pipeline.swift
+++ b/Sources/Saga/Saga+Pipeline.swift
@@ -136,12 +136,27 @@ extension Saga {
             let date = try resolveDate(from: decoder)
             let metadata = try M(from: decoder)
 
+            // Resolve the two title variants with their respective priorities.
+            //
+            // item.title  — display heading (<h1>): # heading wins, then title:, then filename.
+            // item.seoTitle — HTML <title> / meta tags: title: wins, then # heading, then filename.
+            //
+            // When only one source is present both resolve to the same string, preserving
+            // existing behaviour. When both are present authors get independent control over
+            // the page heading and the SEO title.
+            let frontmatterTitle = partial.frontmatter?["title"]
+            let headingTitle = partial.title
+            let fallback = file.relativePath.lastComponentWithoutExtension
+            let resolvedTitle    = headingTitle    ?? frontmatterTitle ?? fallback
+            let resolvedSeoTitle = frontmatterTitle ?? headingTitle    ?? fallback
+
             // Create the Item instance
             let item = Item(
               absoluteSource: file.path,
               relativeSource: file.relativePath,
               relativeDestination: file.relativePath.makeOutputPath(itemWriteMode: itemWriteMode),
-              title: partial.frontmatter?["title"] ?? partial.title ?? file.relativePath.lastComponentWithoutExtension,
+              title: resolvedTitle,
+              seoTitle: resolvedSeoTitle,
               body: partial.body,
               date: date ?? self.fileIO.creationDate(file.path) ?? Date(),
               created: self.fileIO.creationDate(file.path) ?? Date(),

--- a/Sources/Saga/StepBuilder.swift
+++ b/Sources/Saga/StepBuilder.swift
@@ -490,6 +490,7 @@ public class StepBuilder: @unchecked Sendable {
               relativeSource: readPath,
               relativeDestination: readPath + Path("index.html"),
               title: subFolderPath.lastComponent,
+              seoTitle: subFolderPath.lastComponent,
               body: "",
               date: Date(),
               created: Date(),


### PR DESCRIPTION
I launched my site and now realized that Saga doesn't keep the page title and the h1 separate. It is best SEO practice to have a page title that is in the meta data and the h1 can be a separate shown on the page to the user. I think that the change below should give flexibility for this and still ensure that neither are blank as they have sane fallbacks. Hope this works to merge. Let me know if you want me to make any further changes.

## Problem

`Item.title` currently serves double duty — it populates both the HTML `<title>` tag (SEO) and the visible `<h1>` on the page. When a `# ` heading exists in the markdown body alongside a `title:` front matter key, Parsley extracts the heading but Saga silently discards it, using the front matter title for both purposes.

This makes it impossible to have a keyword-optimised SEO title that differs from the human-readable page heading — a standard and well-documented SEO practice.

## Solution

Add `Item.seoTitle` as a distinct property with mirrored priority chains:

| Property | Priority | Intended use |
|---|---|---|
| `item.title` | `# heading` → `title:` → filename | Visible `<h1>` on the page |
| `item.seoTitle` | `title:` → `# heading` → filename | HTML `<title>` tag and meta tags |

Both properties always resolve to a non-empty string — no nil-checks or fallback operators needed in templates.

## Backward compatibility

- **Only `title:` in front matter** → both properties resolve to the same string. No change.
- **Only `# ` heading, no `title:`** → both properties resolve to the same string. No change.
- **Both present, same text** → both resolve to the same string. No change.
- **Both present, different text** → new capability: independent heading and SEO title. The previous behaviour (silently discarding the `# ` heading) was data loss.

## Template migration

Templates that use `item.title` for the HTML `<title>` tag should switch to `item.seoTitle`. No change is required when only one title source is used — the values will be identical.